### PR TITLE
Resolve `[hash]` deprecation

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
     entry: ['./src/app.js'],
     output: {
         path: path.join(__dirname, buildPath),
-        filename: '[name].[hash].js',
+        filename: '[name].[fullhash].js',
         publicPath: `/${pkg.repository}/`,
     },
     target: 'web',


### PR DESCRIPTION
When building with webpack, I see this warning:
```
(node:89636) [DEP_WEBPACK_TEMPLATE_PATH_PLUGIN_REPLACE_PATH_VARIABLES_HASH] DeprecationWarning: [hash] is now [fullhash] (also consider using [chunkhash] or [contenthash], see documentation for details)
```
I changed `[hash]` to `[fullhash]` in the output filename in `webpack.config.js`.